### PR TITLE
Bug fixes and cherry-pick a bit more from nwf/master

### DIFF
--- a/model/measure-sweeping-revocation.py
+++ b/model/measure-sweeping-revocation.py
@@ -658,15 +658,19 @@ class RenderedAllocationMapOutput(DirectoryOutput):
         if not addr_ivals:
             return
 
-        now = run.timestamp_ns
-        img = Image.new('RGB', self._geom)
-
-        # Use the first address being tracked
+        # Use the first address being tracked as the base of the image
         baseva = addr_ivals[0].begin
 
         # Just how big is this image, anyway?
         # Assume 16-byte alignment, so one pixel per 16 bytes.
-        topva = baseva + img.width * img.height * 16
+        topva = baseva + self._geom[0] * self._geom[1] * 16
+
+        # OK, now slice, so we don't spend all our time considering things
+        # that are off the map anyway.
+        addr_ivals = alloc_state.addr_ivals_sorted(begin=baseva, end=topva)
+
+        now = run.timestamp_ns
+        img = Image.new('RGB', self._geom)
 
         # Extract Z order from image width
         zo = img.width.bit_length() << 1

--- a/sim/SegFreeList.py
+++ b/sim/SegFreeList.py
@@ -139,13 +139,13 @@ class SegFreeListBase :
 
   def _insert_intcoal(self, va, sz, front=False) :
     end = va + sz
+    radn = self.adns.get(end)                            # coalesced right
+    if radn is not None :
+      sz += self._remove_intcoal(end)
     lsva = self.acod.get(va)                             # coalesced left
     if lsva is not None :
       va = lsva
-      self._remove_common(lsva)
-    radn = self.adns.get(end)                            # coalesced right
-    if radn is not None :
-      end += self._remove_common(end)
+      sz += self._remove_intcoal(lsva)
     self._insert_core(va, sz, front)
     self.acod[va+sz] = va
 
@@ -197,7 +197,7 @@ class SegFreeListBase :
       startva = self.acod[endva]
       (sdn, _) = self.adns[startva]
       (_, sz) = sdn.value
-      assert endva == startva + sz, ("End mismatch")
+      assert endva == startva + sz, ("End mismatch", endva, startva, sz)
     return self._crossreference_asserts_common()
 
   def _crossreference_asserts_extcoal(self) :


### PR DESCRIPTION
DLMallocish passes `chromium-jemalloc-run-info-20190110_135528-fixed-trace` at paranoia=1 and without objection from the model.